### PR TITLE
Trim output text.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -247,7 +247,7 @@ export default class RunSnippets extends Plugin {
 function writeResult(editor, result: string, outputLine: number) {
 
     let output = `\n\`\`\`output
-${result}    
+${result ? result.trim() : result}    
 \`\`\`
 `
     editor.getDoc().replaceRange(output, {line: outputLine, ch: 0});


### PR DESCRIPTION
I was noticing that several blanks lines were being added to the end of the output code fence after running snippets. This change trims the leading and trailing white space.