### PR TITLE
Don't error on non-markdown views

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,7 @@ export default class RunSnippets extends Plugin {
     get_vars(): Promise<String> {
         let active_view = app.workspace.getActiveViewOfType(MarkdownView);
         if (active_view == null) {
-            throw new Error("Active view is null");
+            return;
         }
 
         let vaultPath = this.app.vault.adapter.basePath;

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,10 +76,10 @@ export default class RunSnippets extends Plugin {
         this.addRunButtons();
     }
 
-    get_vars(): Promise<String> {
+    get_vars() {
         let active_view = app.workspace.getActiveViewOfType(MarkdownView);
         if (active_view == null) {
-            return;
+            return null;
         }
 
         let vaultPath = this.app.vault.adapter.basePath;
@@ -102,6 +102,9 @@ export default class RunSnippets extends Plugin {
 
 
         let vars = this.get_vars();
+
+        if (!vars) return;
+        
         let variants = this.settings.variants
 
         document.querySelectorAll("pre > code").forEach(function (codeBlock) {
@@ -189,6 +192,9 @@ export default class RunSnippets extends Plugin {
      */
     runSnippet() {
         let vars = this.get_vars();
+
+        if (!vars) return;
+        
         let variants = this.settings.variants
 
         const view = this.app.workspace.activeLeaf.view;


### PR DESCRIPTION
Hey @cristianvasquez!

It seems this plugin breaks the Kanban plugin when enabled because it throws an error if a markdown view isn't found (Kanban uses it's own view type). This PR silently prevents execution if no markdown view is found.